### PR TITLE
feat: use 1-based indexing for referencing CLI args

### DIFF
--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -119,7 +119,7 @@ func Run(ctx context.Context, args ...string) (err error) {
 	}
 
 	req, err := executor.BuildRequest(id, &executorPkg.RequestOpts{
-		Params: args,
+		Params: args[1:],
 	})
 	if err != nil {
 		return fmt.Errorf("build request: %v", err)

--- a/pkg/test/core/core_test.go
+++ b/pkg/test/core/core_test.go
@@ -192,7 +192,7 @@ func TestBasic(t *testing.T) {
 	})
 	t.Run("no input from CLI returns an error", func(t *testing.T) {
 		req, err := e.BuildRequest("cli-arg-types", &executor.RequestOpts{
-			Params: []string{"hit-test", "@req"},
+			Params: []string{"@req"},
 		})
 		require.Nil(t, req)
 		require.ErrorContains(t, err,
@@ -200,7 +200,7 @@ func TestBasic(t *testing.T) {
 	})
 	t.Run("string input via CLI is injected", func(t *testing.T) {
 		req, err := e.BuildRequest("cli-arg-types", &executor.RequestOpts{
-			Params: []string{"hit-test", "@req", "foobar"},
+			Params: []string{"@req", "foobar"},
 		})
 		require.Nil(t, err)
 		require.Equal(t, "https://httpbin.org/anything/foobar",
@@ -214,7 +214,7 @@ func TestBasic(t *testing.T) {
 	})
 	t.Run("number input via CLI is injected", func(t *testing.T) {
 		req, err := e.BuildRequest("cli-arg-types", &executor.RequestOpts{
-			Params: []string{"hit-test", "@req", "42"},
+			Params: []string{"@req", "42"},
 		})
 		require.Nil(t, err)
 		require.Equal(t, "https://httpbin.org/anything/42",
@@ -228,7 +228,7 @@ func TestBasic(t *testing.T) {
 	})
 	t.Run("float input via CLI is injected", func(t *testing.T) {
 		req, err := e.BuildRequest("cli-arg-types", &executor.RequestOpts{
-			Params: []string{"hit-test", "@req", "42.2442"},
+			Params: []string{"@req", "42.2442"},
 		})
 		require.Nil(t, err)
 		require.Equal(t, "https://httpbin.org/anything/42.2442",
@@ -242,7 +242,7 @@ func TestBasic(t *testing.T) {
 	})
 	t.Run("bool true input via CLI is injected", func(t *testing.T) {
 		req, err := e.BuildRequest("cli-arg-types", &executor.RequestOpts{
-			Params: []string{"hit-test", "@req", "true"},
+			Params: []string{"@req", "true"},
 		})
 		require.Nil(t, err)
 		require.Equal(t, "https://httpbin.org/anything/true",
@@ -256,7 +256,7 @@ func TestBasic(t *testing.T) {
 	})
 	t.Run("bool false input via CLI is injected", func(t *testing.T) {
 		req, err := e.BuildRequest("cli-arg-types", &executor.RequestOpts{
-			Params: []string{"hit-test", "@req", "false"},
+			Params: []string{"@req", "false"},
 		})
 		require.Nil(t, err)
 		require.Equal(t, "https://httpbin.org/anything/false",
@@ -270,7 +270,7 @@ func TestBasic(t *testing.T) {
 	})
 	t.Run("redirects are not followed", func(t *testing.T) {
 		req, err := e.BuildRequest("redirect", &executor.RequestOpts{
-			Params: []string{"hit-test", "@req"},
+			Params: []string{"@req"},
 		})
 		require.Nil(t, err)
 		require.Equal(t, "https://httpbin.org/status/302",

--- a/pkg/test/core/test.hit
+++ b/pkg/test/core/test.hit
@@ -44,9 +44,9 @@ GET
 
 @cli-arg-types
 POST
-/anything/@2
+/anything/@1
 ~hy2j
-input: "@2"
+input: "@1"
 
 
 @post-with-static-body

--- a/test.hit
+++ b/test.hit
@@ -12,15 +12,15 @@ title: root-node
 
 @get-node
 GET
-/v1/node/@2
+/v1/node/@1
 
 @create-node
 POST
 /v1/node
 ~hy2j
-title: "@2"
-parent_id: "@3"
+title: "@1"
+parent_id: "@2"
 
 @delete-node
 DELETE
-/v1/node/@2
+/v1/node/@1


### PR DESCRIPTION
The feedback from users is that 2-based indexing isn't intuitive and
trips them often. 1-based indexing is a no-brainer for most parts.