### PR TITLE
fix: improve errors for cli arguments

### DIFF
--- a/pkg/request/resolver.go
+++ b/pkg/request/resolver.go
@@ -29,7 +29,11 @@ func (r cacheResolver) Resolve(key string) (interface{}, error) {
 	if err == nil {
 		// referenced key is a number
 		if n >= len(r.args) {
-			return nil, fmt.Errorf("expected command-line input for the request")
+			return nil, fmt.Errorf(
+				"cannot find command-line argument number '@%d'", n)
+		}
+		if n == 0 {
+			return nil, fmt.Errorf("positional argument must be greater than 0")
 		}
 		v := r.args[n]
 		if v[0] != '@' {

--- a/pkg/test/core/core_test.go
+++ b/pkg/test/core/core_test.go
@@ -196,7 +196,7 @@ func TestBasic(t *testing.T) {
 		})
 		require.Nil(t, req)
 		require.ErrorContains(t, err,
-			"expected command-line input for the request")
+			"cannot find command-line argument number '@1'")
 	})
 	t.Run("string input via CLI is injected", func(t *testing.T) {
 		req, err := e.BuildRequest("cli-arg-types", &executor.RequestOpts{
@@ -211,6 +211,15 @@ func TestBasic(t *testing.T) {
 		js := gjsonBody(t, res)
 		input := js.Get("json.input").String()
 		require.Equal(t, "foobar", input)
+	})
+	t.Run("referencing $0 errors", func(t *testing.T) {
+		req, err := e.BuildRequest("bad-cli-arg", &executor.RequestOpts{
+			Params: []string{"@req"},
+		})
+		require.Nil(t, req)
+		require.NotNil(t, err)
+		require.ErrorContains(t, err,
+			"positional argument must be greater than 0")
 	})
 	t.Run("number input via CLI is injected", func(t *testing.T) {
 		req, err := e.BuildRequest("cli-arg-types", &executor.RequestOpts{

--- a/pkg/test/core/test.hit
+++ b/pkg/test/core/test.hit
@@ -69,3 +69,8 @@ num-float: 42.42
 @redirect
 GET
 /status/302
+
+
+@bad-cli-arg
+POST
+/anything/@0


### PR DESCRIPTION
Disallow @0 and make the user-facing error a bit more helpful. I'm not
happy with the error message but I don't hate it as much so I count that
as an improvement.