### PR TITLE
fix: populate host header during request generation

### DIFF
--- a/pkg/request/request.go
+++ b/pkg/request/request.go
@@ -38,10 +38,18 @@ func Generate(request parser.Request, opts Options) (model.Request, error) {
 		return model.Request{}, err
 	}
 	headers := http.Header{}
-	if request.Headers != nil {
-		headers = http.Header(request.Headers).Clone()
+	for key, values := range request.Headers {
+		for _, value := range values {
+			headers.Add(key, value)
+		}
 	}
 	headers.Add("user-agent", "hit/"+version.Version)
+
+	if headers.Get("host") == "" {
+		// TODO(hbagdi): attempt to clean host or error out if host is not
+		// valid
+		headers.Set("host", urlComponents.host)
+	}
 
 	switch cType {
 	case contentTypeNone:

--- a/pkg/test/core/core_test.go
+++ b/pkg/test/core/core_test.go
@@ -73,6 +73,7 @@ func TestBasic(t *testing.T) {
 		require.Nil(t, err)
 		require.NotNil(t, req)
 		require.Equal(t, "https://httpbin.org/headers", req.URL())
+		require.Equal(t, "httpbin.org", req.Header.Get("host"))
 		require.Empty(t, req.Header.Get("content-type"))
 	})
 	t.Run("successfully performs a basic request", func(t *testing.T) {
@@ -315,6 +316,14 @@ func TestBasic(t *testing.T) {
 		require.Nil(t, err)
 		require.Equal(t, http.StatusFound, res.Response.Code)
 		require.Equal(t, res.Response.Header.Get("location"), "/redirect/1")
+	})
+	t.Run("an explicit host header is not overwritten", func(t *testing.T) {
+		id := "request-with-host-header"
+		req, err := e.BuildRequest(id, &executor.RequestOpts{
+			Params: []string{"@req"},
+		})
+		require.Nil(t, err)
+		require.Equal(t, "foo.com", req.Header.Get("host"))
 	})
 }
 

--- a/pkg/test/core/test.hit
+++ b/pkg/test/core/test.hit
@@ -82,3 +82,8 @@ POST
 @invalid-req-ref
 POST
 /anything/@redirect
+
+@request-with-host-header
+POST
+/anything
+host:foo.com


### PR DESCRIPTION
Go's client adds in host header (if not present) using request's URL.
hit doesn't see this header since it is only populated during request
execution i.e. when the request is written on the wire.

With this patch, the host header is populated when model.Request is
generated from a parsed request. This ensures that the console output
and the save request have the host header.

Additionally, the request headers are now populated using appropriate
http.Header.Add method rather than cloning a type casted
map[string][]string. This ensures that the headers are correctly
canonicalized in the underlying map.