### PR TITLE
feat: consolidate method and path on the same line

### DIFF
--- a/pkg/test/core/test.hit
+++ b/pkg/test/core/test.hit
@@ -4,14 +4,12 @@ version=1
 
 
 @get-headers
-GET
-/headers
+GET /headers
 foo:bar
 
 
 @populate-cache
-POST
-/anything
+POST /anything
 ~y2j
 string: foobar
 bool-true: true
@@ -20,8 +18,7 @@ num: 42
 num-float: 42.42
 
 @get-using-cache
-GET
-/anything
+GET /anything
 foo:bar
 ~hy2j
 string: "@populate-cache.json.string"
@@ -31,34 +28,28 @@ num: "@populate-cache.json.num"
 num-float: "@populate-cache.json.num-float"
 
 @get-cache-ref-in-path
-GET
-/anything/@populate-cache.json.string
+GET /anything/@populate-cache.json.string
 
 @get-cache-ref-in-path-in-middle
-GET
-/anything/@populate-cache.json.string/baz
+GET /anything/@populate-cache.json.string/baz
 
 @get-cache-ref-in-query-param
-GET
-/anything/qp?foo=@populate-cache.json.num
+GET /anything/qp?foo=@populate-cache.json.num
 
 @cli-arg-types
-POST
-/anything/@1
+POST /anything/@1
 ~hy2j
 input: "@1"
 
 
 @post-with-static-body
-POST
-/anything
+POST /anything
 ~y2j
 foo: bar
 baz: buz
 
 @post-static-json
-POST
-/anything
+POST /anything
 ~y2j
 string: foobar
 bool-true: true
@@ -67,23 +58,18 @@ num: 42
 num-float: 42.42
 
 @redirect
-GET
-/status/302
+GET /status/302
 
 
 @bad-cli-arg
-POST
-/anything/@0
+POST /anything/@0
 
 @invalid-ref
-POST
-/anything/@
+POST /anything/@
 
 @invalid-req-ref
-POST
-/anything/@redirect
+POST /anything/@redirect
 
 @request-with-host-header
-POST
-/anything
+POST /anything
 host:foo.com

--- a/pkg/test/invalid_request_line/core_test.go
+++ b/pkg/test/invalid_request_line/core_test.go
@@ -1,0 +1,29 @@
+package core
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hbagdi/hit/pkg/cache"
+	"github.com/hbagdi/hit/pkg/db"
+	"github.com/hbagdi/hit/pkg/executor"
+	"github.com/hbagdi/hit/pkg/log"
+	"github.com/stretchr/testify/require"
+)
+
+var c cache.Cache
+
+func init() {
+	store, err := db.NewStore(db.StoreOpts{Logger: log.Logger})
+	if err != nil {
+		panic(fmt.Errorf("init test db: %v", err))
+	}
+	c = cache.GetDBCache(store)
+}
+
+func TestInvalidRequestLine(t *testing.T) {
+	e, err := executor.NewExecutor(&executor.Opts{Cache: c})
+	require.Nil(t, err)
+	err = e.LoadFiles()
+	require.ErrorContains(t, err, "invalid request line")
+}

--- a/pkg/test/invalid_request_line/test.hit
+++ b/pkg/test/invalid_request_line/test.hit
@@ -4,6 +4,5 @@ version=1
 
 
 @get-headers
-GET /headers
-foo:bar
-
+GET
+/headers

--- a/test.hit
+++ b/test.hit
@@ -4,23 +4,19 @@ version=1
 
 
 @gen-root-node
-POST
-/v1/node
+POST /v1/node
 ~y2j
 title: root-node
 
 
 @get-node
-GET
-/v1/node/@1
+GET /v1/node/@1
 
 @create-node
-POST
-/v1/node
+POST /v1/node
 ~hy2j
 title: "@1"
 parent_id: "@2"
 
 @delete-node
-DELETE
-/v1/node/@1
+DELETE /v1/node/@1


### PR DESCRIPTION
Based on user feedback, the path of the request is being moved together
with method. This is closer to on the wire semantics of RFC 2616 and is
more familiar to users.

This is a breaking change and all users of hit must update their hit
files.