### PR TITLE
feat: drop hy2j content-type

### DIFF
--- a/pkg/request/request.go
+++ b/pkg/request/request.go
@@ -1,7 +1,6 @@
 package request
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -15,8 +14,7 @@ import (
 )
 
 const (
-	encodingY2J  = "y2j"
-	encodingHY2J = "hy2j"
+	encodingY2J = "y2j"
 )
 
 type Options struct {
@@ -183,28 +181,18 @@ func resolveBody(request parser.Request, resolver resolver) ([]byte, contentType
 	}
 	switch request.BodyEncoding {
 	case encodingY2J:
-		var i interface{}
-		err := yaml.Unmarshal([]byte(bodyS), &i)
-		if err != nil {
-			return nil, contentTypeInvalid, err
-		}
-		body, err = json.Marshal(i)
-		if err != nil {
-			return nil, contentTypeInvalid, err
-		}
-	case encodingHY2J:
 		jsonBytes, err := yaml.YAMLToJSON([]byte(bodyS))
 		if err != nil {
-			return nil, contentTypeInvalid, err
+			return nil, contentTypeNone, err
 		}
 		r := &BodyResolver{resolver: resolver}
 		body, err = r.Resolve(jsonBytes)
 		if err != nil {
-			return nil, contentTypeInvalid, err
+			return nil, contentTypeNone, err
 		}
 	case "":
 	default:
-		return nil, contentTypeInvalid,
+		return nil, contentTypeNone,
 			fmt.Errorf("invalid encoding: %v", request.BodyEncoding)
 	}
 	return body, contentTypeJSON, nil

--- a/pkg/test/core/test.hit
+++ b/pkg/test/core/test.hit
@@ -20,7 +20,7 @@ num-float: 42.42
 @get-using-cache
 GET /anything
 foo:bar
-~hy2j
+~y2j
 string: "@populate-cache.json.string"
 bool-true: "@populate-cache.json.bool-true"
 bool-false: "@populate-cache.json.bool-false"
@@ -38,7 +38,7 @@ GET /anything/qp?foo=@populate-cache.json.num
 
 @cli-arg-types
 POST /anything/@1
-~hy2j
+~y2j
 input: "@1"
 
 

--- a/test.hit
+++ b/test.hit
@@ -14,7 +14,7 @@ GET /v1/node/@1
 
 @create-node
 POST /v1/node
-~hy2j
+~y2j
 title: "@1"
 parent_id: "@2"
 


### PR DESCRIPTION
The difference between body encoding hy2j and y2j is subtle and annoying.
Users start out with y2j and slowly start using variable substitution.

With this change, users can do not need to use body-encoding hy2j
explicitly to instruct hit to substitute variables. All variables are automatically substituted.

This is a breaking change for all users of hit.