### PR TITLE
feat: body is now enclosed with '~' lines

### DIFF
--- a/pkg/test/core/test.hit
+++ b/pkg/test/core/test.hit
@@ -16,6 +16,7 @@ bool-true: true
 bool-false: false
 num: 42
 num-float: 42.42
+~
 
 @get-using-cache
 GET /anything
@@ -26,6 +27,7 @@ bool-true: "@populate-cache.json.bool-true"
 bool-false: "@populate-cache.json.bool-false"
 num: "@populate-cache.json.num"
 num-float: "@populate-cache.json.num-float"
+~
 
 @get-cache-ref-in-path
 GET /anything/@populate-cache.json.string
@@ -40,6 +42,7 @@ GET /anything/qp?foo=@populate-cache.json.num
 POST /anything/@1
 ~y2j
 input: "@1"
+~
 
 
 @post-with-static-body
@@ -47,6 +50,7 @@ POST /anything
 ~y2j
 foo: bar
 baz: buz
+~
 
 @post-static-json
 POST /anything
@@ -56,6 +60,7 @@ bool-true: true
 bool-false: false
 num: 42
 num-float: 42.42
+~
 
 @redirect
 GET /status/302

--- a/test.hit
+++ b/test.hit
@@ -7,6 +7,7 @@ version=1
 POST /v1/node
 ~y2j
 title: root-node
+~
 
 
 @get-node
@@ -17,6 +18,7 @@ POST /v1/node
 ~y2j
 title: "@1"
 parent_id: "@2"
+~
 
 @delete-node
 DELETE /v1/node/@1


### PR DESCRIPTION
The body of the request now must start with a `~` as the first line with
an optional body encoding and end with a line contianing `~`. These
lines are not sent on the wire.

The change was done to make hit files a bit more expressive
This is breaking change for all hit users.
