### PR TITLE
fix: content-type header must not be sent for empty body encoding

### DIFF
--- a/pkg/test/core/core_test.go
+++ b/pkg/test/core/core_test.go
@@ -325,6 +325,16 @@ func TestBasic(t *testing.T) {
 		require.Nil(t, err)
 		require.Equal(t, "foo.com", req.Header.Get("host"))
 	})
+	t.Run("no body encoding requests are sent as is", func(t *testing.T) {
+		id := "no-body-encoding"
+		req, err := e.BuildRequest(id, &executor.RequestOpts{
+			Params: []string{"@req"},
+		})
+		require.Nil(t, err)
+		require.Emptyf(t, req.Header.Get("content-type"),
+			"no content-type header is set")
+		require.Equal(t, "plain-text body", string(req.Body))
+	})
 }
 
 func gjsonBody(t *testing.T, body []byte) gjson.Result {

--- a/pkg/test/core/test.hit
+++ b/pkg/test/core/test.hit
@@ -78,3 +78,9 @@ POST /anything/@redirect
 @request-with-host-header
 POST /anything
 host:foo.com
+
+@no-body-encoding
+POST /foobar
+~
+plain-text body
+~


### PR DESCRIPTION
And also ensure that body is actually parsed and sent in the request.
