### PR TITLE
feat: update @_global section and support global headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ sudo cp /tmp/hit /usr/local/bin/
 Create a hit file:
 ```shell
 echo '@_global
-base_url=https://nodes.yolo42.com
+baseURL=https://nodes.yolo42.com
 version=1
 
 

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -68,7 +68,7 @@ func validateGlobal(g parser.Global) error {
 	if g.BaseURL != "" {
 		u, err := url.Parse(g.BaseURL)
 		if err != nil {
-			return fmt.Errorf("invalid base_url '%v': %v", g.BaseURL, err)
+			return fmt.Errorf("invalid baseURL '%v': %v", g.BaseURL, err)
 		}
 		if u.Scheme != "http" && u.Scheme != "https" {
 			return fmt.Errorf("invalid scheme '%v': only 'http' "+
@@ -90,12 +90,15 @@ func fetchGlobal(files []parser.File) (parser.Global, error) {
 		if res.BaseURL == "" && file.Global.BaseURL != "" {
 			res.BaseURL = file.Global.BaseURL
 		}
+		if res.Headers == nil && file.Global.Headers != nil {
+			res.Headers = file.Global.Headers
+		}
 	}
 	if res.Version != 1 {
 		return parser.Global{}, fmt.Errorf("no global.version")
 	}
 	if res.BaseURL == "" {
-		return parser.Global{}, fmt.Errorf("no global.base_url provided")
+		return parser.Global{}, fmt.Errorf("no global.baseURL provided")
 	}
 	return res, nil
 }
@@ -195,7 +198,6 @@ func (e *Executor) Execute(ctx context.Context, requestID string, req model.Requ
 func httpRequestFromHitRequest(req model.Request) (*http.Request, error) {
 	body := bytes.NewReader(req.Body)
 
-	//nolint:noctx
 	httpRequest, err := http.NewRequest(req.Method, req.URL(), body)
 	if err != nil {
 		return nil, fmt.Errorf("create HTTP request: %w", err)

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -198,7 +198,7 @@ func (e *Executor) Execute(ctx context.Context, requestID string, req model.Requ
 func httpRequestFromHitRequest(req model.Request) (*http.Request, error) {
 	body := bytes.NewReader(req.Body)
 
-	httpRequest, err := http.NewRequest(req.Method, req.URL(), body)
+	httpRequest, err := http.NewRequest(req.Method, req.URL(), body) //nolint:noctx
 	if err != nil {
 		return nil, fmt.Errorf("create HTTP request: %w", err)
 	}

--- a/pkg/request/request.go
+++ b/pkg/request/request.go
@@ -43,6 +43,11 @@ func Generate(request parser.Request, opts Options) (model.Request, error) {
 	}
 	headers.Add("user-agent", "hit/"+version.Version)
 
+	for k, v := range opts.GlobalContext.Headers {
+		if headers.Get(k) == "" {
+			headers.Add(k, v)
+		}
+	}
 	if headers.Get("host") == "" {
 		// TODO(hbagdi): attempt to clean host or error out if host is not
 		// valid

--- a/pkg/test/core/test.hit
+++ b/pkg/test/core/test.hit
@@ -1,6 +1,8 @@
 @_global
-base_url=https://httpbin.org
-version=1
+~
+baseURL: https://httpbin.org
+version: 1
+~
 
 
 @get-headers

--- a/pkg/test/global_headers/core_test.go
+++ b/pkg/test/global_headers/core_test.go
@@ -1,0 +1,80 @@
+package core
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/hbagdi/hit/pkg/cache"
+	"github.com/hbagdi/hit/pkg/db"
+	"github.com/hbagdi/hit/pkg/executor"
+	"github.com/hbagdi/hit/pkg/log"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+var c cache.Cache
+
+func init() {
+	store, err := db.NewStore(db.StoreOpts{Logger: log.Logger})
+	if err != nil {
+		panic(fmt.Errorf("init test db: %v", err))
+	}
+	c = cache.GetDBCache(store)
+}
+
+func TestMain(m *testing.M) {
+	var code int
+	defer func() {
+		err := c.Flush()
+		if err != nil {
+			panic(fmt.Sprintf("failed to flush cache: %v", err))
+		}
+		os.Exit(code)
+	}()
+	code = m.Run()
+}
+
+func testExecutor(t *testing.T) *executor.Executor {
+	t.Helper()
+	e, err := executor.NewExecutor(&executor.Opts{Cache: c})
+	require.Nil(t, err)
+	return e
+}
+
+func TestBasic(t *testing.T) {
+	e := testExecutor(t)
+	defer e.Close()
+
+	require.Nil(t, e.LoadFiles())
+
+	t.Run("successfully performs a basic request", func(t *testing.T) {
+		id := "get-headers"
+		req, err := e.BuildRequest(id, nil)
+		require.Nil(t, err)
+		require.NotNil(t, req)
+		require.Equal(t, "https://httpbin.org/headers", req.URL())
+		require.Equal(t, "yes!!!!", req.Header.Get("global-header"))
+
+		res, err := e.Execute(context.Background(), id, req)
+		require.Nil(t, err)
+		require.NotNil(t, res)
+		require.Equal(t, http.StatusOK, res.Response.Code)
+
+		body := gjsonBody(t, res.Response.Body)
+		require.Equal(t, "bar", body.Get("headers.Foo").String())
+		require.Equal(t, "yes!!!!", body.Get("headers.Global-Header").String())
+	})
+}
+
+func gjsonBody(t *testing.T, body []byte) gjson.Result {
+	t.Helper()
+	if !gjson.Valid(string(body)) {
+		require.FailNow(t, "invalid JSON in the body")
+	}
+
+	js := gjson.ParseBytes(body)
+	return js
+}

--- a/pkg/test/global_headers/test.hit
+++ b/pkg/test/global_headers/test.hit
@@ -1,0 +1,12 @@
+@_global
+~
+baseURL: https://httpbin.org
+version: 1
+headers:
+  global-header: yes!!!!
+~
+
+
+@get-headers
+GET /headers
+foo:bar

--- a/pkg/test/invalid_request_line/test.hit
+++ b/pkg/test/invalid_request_line/test.hit
@@ -1,6 +1,8 @@
 @_global
-base_url=ftp://httpbin.org
-version=1
+~
+baseURL: ftp://httpbin.org
+version: 1
+~
 
 
 @get-headers

--- a/pkg/test/invalid_scheme/test.hit
+++ b/pkg/test/invalid_scheme/test.hit
@@ -1,6 +1,8 @@
 @_global
-base_url=ftp://httpbin.org
-version=1
+~
+baseURL: ftp://httpbin.org
+version: 1
+~
 
 
 @get-headers

--- a/test.hit
+++ b/test.hit
@@ -1,6 +1,8 @@
 @_global
-base_url=http://localhost:7090
-version=1
+~
+baseURL: http://localhost:7090
+version: 1
+~
 
 
 @gen-root-node


### PR DESCRIPTION
@_global section is now similar to an HTTP body.
The custom language inside @_global has been replaced with a YAML
configuration instead.
No variable referencing is supported at this point.

This is a breaking change for all users of hit.

Additionally, a new field 'headers' has been introduced to inject
headers into all requests.
