### PR TITLE
chore: upgrade linter to v1.49.0

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup golangci-lint
         uses: golangci/golangci-lint-action@v3.2.0
         with:
-          version: v1.48.0
+          version: v1.49.0
       - name: lint
         run: make lint
   test:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -6,7 +6,6 @@ linters:
     - bidichk
     - bodyclose
     - contextcheck
-    - deadcode
     - depguard
     - dogsled
     - dupl
@@ -33,7 +32,6 @@ linters:
     - gosec
     - gosimple
     - govet
-    - ifshort
     - importas
     - ineffassign
     - lll
@@ -52,7 +50,6 @@ linters:
     - rowserrcheck
     - sqlclosecheck
     - staticcheck
-    - structcheck
     - stylecheck
     - tenv
     - thelper
@@ -61,7 +58,6 @@ linters:
     - unconvert
     - unparam
     - unused
-    - varcheck
     - wastedassign
     - whitespace
 issues:

--- a/pkg/cmd/browse.go
+++ b/pkg/cmd/browse.go
@@ -285,8 +285,8 @@ func (b *browser) refreshListView() {
 	}
 }
 
-func newBrowser(store *db.Store) (*browser, error) {
-	hits, err := store.List(context.Background(), db.PageOpts{})
+func newBrowser(ctx context.Context, store *db.Store) (*browser, error) {
+	hits, err := store.List(ctx, db.PageOpts{})
 	if err != nil {
 		return nil, fmt.Errorf("hitsList requests: %v", err)
 	}
@@ -304,8 +304,8 @@ func newBrowser(store *db.Store) (*browser, error) {
 	return b, nil
 }
 
-func executeBrowse() error {
-	store, err := db.NewStore(db.StoreOpts{Logger: log.Logger})
+func executeBrowse(ctx context.Context) error {
+	store, err := db.NewStore(ctx, db.StoreOpts{Logger: log.Logger})
 	if err != nil {
 		return fmt.Errorf("set up DB: %v", err)
 	}
@@ -315,7 +315,7 @@ func executeBrowse() error {
 			log.Logger.Sugar().Errorf("failed to close store: %v", err)
 		}
 	}()
-	b, err := newBrowser(store)
+	b, err := newBrowser(ctx, store)
 	if err != nil {
 		return fmt.Errorf("set up browser :%v", err)
 	}

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -76,14 +76,14 @@ func Run(ctx context.Context, args ...string) (err error) {
 	case id == "version":
 		return executeVersion()
 	case id == "browse":
-		return executeBrowse()
+		return executeBrowse(ctx)
 	case id[0] == '@':
 	default:
 		return fmt.Errorf("request must begin with '@' character")
 	}
 	id = id[1:]
 
-	store, err := db.NewStore(db.StoreOpts{Logger: log.Logger})
+	store, err := db.NewStore(ctx, db.StoreOpts{Logger: log.Logger})
 	if err != nil {
 		return err
 	}

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -225,7 +225,7 @@ func genDSN(fileName string) string {
 	return dsn
 }
 
-func NewStore(opts StoreOpts) (*Store, error) {
+func NewStore(ctx context.Context, opts StoreOpts) (*Store, error) {
 	dsn := genDSN(dbFilePath)
 	db, err := sql.Open("sqlite3", dsn)
 	if err != nil {
@@ -234,7 +234,7 @@ func NewStore(opts StoreOpts) (*Store, error) {
 	if opts.Logger == nil {
 		return nil, fmt.Errorf("no logger")
 	}
-	err = migrate(db)
+	err = migrate(ctx, db)
 	if err != nil {
 		return nil, fmt.Errorf("ensure migrations up to date: %v", err)
 	}

--- a/pkg/db/db_test.go
+++ b/pkg/db/db_test.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"context"
 	"testing"
 
 	"github.com/hbagdi/hit/pkg/log"
@@ -37,7 +38,7 @@ func TestNewStore(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := NewStore(tt.args.opts)
+			_, err := NewStore(context.Background(), tt.args.opts)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("NewStore() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -47,7 +48,7 @@ func TestNewStore(t *testing.T) {
 }
 
 func TestStoreClose(t *testing.T) {
-	store, err := NewStore(StoreOpts{Logger: log.Logger})
+	store, err := NewStore(context.Background(), StoreOpts{Logger: log.Logger})
 	require.NoError(t, err)
 	require.NoError(t, store.Close())
 }

--- a/pkg/test/core/core_test.go
+++ b/pkg/test/core/core_test.go
@@ -18,7 +18,7 @@ import (
 var c cache.Cache
 
 func init() {
-	store, err := db.NewStore(db.StoreOpts{Logger: log.Logger})
+	store, err := db.NewStore(context.Background(), db.StoreOpts{Logger: log.Logger})
 	if err != nil {
 		panic(fmt.Errorf("init test db: %v", err))
 	}

--- a/pkg/test/global_headers/core_test.go
+++ b/pkg/test/global_headers/core_test.go
@@ -18,7 +18,8 @@ import (
 var c cache.Cache
 
 func init() {
-	store, err := db.NewStore(db.StoreOpts{Logger: log.Logger})
+	store, err := db.NewStore(context.Background(),
+		db.StoreOpts{Logger: log.Logger})
 	if err != nil {
 		panic(fmt.Errorf("init test db: %v", err))
 	}

--- a/pkg/test/invalid_request_line/core_test.go
+++ b/pkg/test/invalid_request_line/core_test.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -14,7 +15,8 @@ import (
 var c cache.Cache
 
 func init() {
-	store, err := db.NewStore(db.StoreOpts{Logger: log.Logger})
+	store, err := db.NewStore(context.Background(), db.StoreOpts{Logger: log.
+		Logger})
 	if err != nil {
 		panic(fmt.Errorf("init test db: %v", err))
 	}

--- a/pkg/test/invalid_scheme/core_test.go
+++ b/pkg/test/invalid_scheme/core_test.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -14,7 +15,8 @@ import (
 var c cache.Cache
 
 func init() {
-	store, err := db.NewStore(db.StoreOpts{Logger: log.Logger})
+	store, err := db.NewStore(context.Background(),
+		db.StoreOpts{Logger: log.Logger})
 	if err != nil {
 		panic(fmt.Errorf("init test db: %v", err))
 	}

--- a/pkg/test/user_agent_override/core_test.go
+++ b/pkg/test/user_agent_override/core_test.go
@@ -18,7 +18,8 @@ import (
 var c cache.Cache
 
 func init() {
-	store, err := db.NewStore(db.StoreOpts{Logger: log.Logger})
+	store, err := db.NewStore(context.Background(),
+		db.StoreOpts{Logger: log.Logger})
 	if err != nil {
 		panic(fmt.Errorf("init test db: %v", err))
 	}


### PR DESCRIPTION
The context propagation was caught by the new linter upgrade and was
fixed in this patch itself.
